### PR TITLE
feat: implement cache on auth credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ count-lines-no-generated-no-test:
 	find . -name '*.go' -not -name 'mock_*.go' -not -name '*_test.go' | xargs wc -l
 
 lint: check-cognitive-complexity
-	golangci-lint run --print-issued-lines=false --exclude-use-default=false --enable=revive --enable=goimports  --enable=unconvert --enable=unparam --concurrency=2
+	golangci-lint run --print-issued-lines=false --exclude-use-default=false --enable=goimports  --enable=unconvert --enable=unparam --concurrency=2
 
 check-gotest:
 ifeq (, $(shell which richgo))
@@ -57,7 +57,8 @@ test-only: check-gotest
 test: lint mockgen test-only
 
 check-cognitive-complexity:
-	find . -type f -name '*.go' -not -name "*.pb.go" -not -name "mock*.go" -not -name "generated.go" -not -name "federation.go" \
+	find . -type f -name '*.go' -not -name "*.pb.go" -not -name "generated.go"\
+	-not -name "mock*.go" -not -name "generated.go"  -not -name "federation.go" \
       -exec gocognit -over 15 {} +
 
 migrate:

--- a/go.sum
+++ b/go.sum
@@ -311,14 +311,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/sweet-go/stdlib v1.2.0 h1:QCZ8vTpuk65oxbDRgBFMRZealaDMJeSgKK7YAsD8Tro=
-github.com/sweet-go/stdlib v1.2.0/go.mod h1:beHl3XlJxehIb1DUioi1lf31Ucx2m+7k7yhkGfhvteY=
-github.com/sweet-go/stdlib v1.2.1-0.20231129072459-a75600e4a037 h1:ySO31Px00+W+c4A74qfWFwFvGO5l3jczqN68bMgyZVg=
-github.com/sweet-go/stdlib v1.2.1-0.20231129072459-a75600e4a037/go.mod h1:beHl3XlJxehIb1DUioi1lf31Ucx2m+7k7yhkGfhvteY=
-github.com/sweet-go/stdlib v1.2.1-0.20240109120126-b1e693774119 h1:gfjlUibeGZKb3+SO15qVDqb+iBGJVTDRpLLi2eFVsqI=
-github.com/sweet-go/stdlib v1.2.1-0.20240109120126-b1e693774119/go.mod h1:beHl3XlJxehIb1DUioi1lf31Ucx2m+7k7yhkGfhvteY=
-github.com/sweet-go/stdlib v1.2.1-0.20240109120724-82a5e31c917b h1:YOxm7BaKx/U6Ycs/TkcgPI0DR+vQ5Q7Sm8Atr+Nhxj8=
-github.com/sweet-go/stdlib v1.2.1-0.20240109120724-82a5e31c917b/go.mod h1:beHl3XlJxehIb1DUioi1lf31Ucx2m+7k7yhkGfhvteY=
 github.com/sweet-go/stdlib v1.2.1-0.20240109123030-b23630ff1149 h1:ajCH9EvYO9CzaoewrvYtYi16z7V7Aw5Tlmy9IJ4OE5c=
 github.com/sweet-go/stdlib v1.2.1-0.20240109123030-b23630ff1149/go.mod h1:beHl3XlJxehIb1DUioi1lf31Ucx2m+7k7yhkGfhvteY=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -81,7 +81,7 @@ func serverFn(_ *cobra.Command, _ []string) {
 	userRepo := repository.NewUserRepository(db.PostgresDB, cacher)
 	pinRepo := repository.NewPinRepository(db.PostgresDB)
 	emailRepo := repository.NewEmailRepository(db.PostgresDB)
-	accessTokenRepo := repository.NewAccessTokenRepository(db.PostgresDB)
+	accessTokenRepo := repository.NewAccessTokenRepository(db.PostgresDB, cacher)
 	sdtemplateRepo := repository.NewSDTemplateRepository(db.PostgresDB)
 	sdpackageRepo := repository.NewSDPackageRepository(db.PostgresDB)
 	sdtRepo := repository.NewSDTestResultRepository(db.PostgresDB)

--- a/internal/model/cacher.go
+++ b/internal/model/cacher.go
@@ -5,6 +5,10 @@ import (
 	"time"
 )
 
+// NilKey is used to indicate that this value / cache is intended to be treated as nil
+// and different from not found from cache
+const NilKey = "NIL"
+
 // Cacher :nodoc:
 type Cacher interface {
 	Get(ctx context.Context, key string) (string, error)


### PR DESCRIPTION
relates to: https://lucky-akbar.atlassian.net/browse/ATEC-51

will add simple caching mechanism on credentials retrieval
the purposes are:

- reduce calls to db
- avoid calls to db if the credentials is already invalid / not found

all functionality added here is not breaking, and any error will result to fallback to db