### PR TITLE
feat: active access token limiter

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -10,6 +10,7 @@ server:
   auth:
     access_token_duration_minutes: 60
     iv: ""
+    active_token_limit: 0
   user:
     change_password_base_url: ""
     change_password_expiry_duration_minutes: 15

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -194,6 +194,16 @@ func RedisMinIdleConn() int {
 	return viper.GetInt("redis.min")
 }
 
+// ActiveTokenLimit will return active token limit. if unset or set with negative value, will return 0
+func ActiveTokenLimit() int {
+	cfg := viper.GetInt("server.auth.active_token_limit")
+	if cfg <= 0 {
+		return 0
+	}
+
+	return cfg
+}
+
 // RedisMaxIdleConn max idle
 func RedisMaxIdleConn() int {
 	return viper.GetInt("redis.max")

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -95,7 +95,7 @@ func serverFn(_ *cobra.Command, _ []string) {
 
 	emailUsecase := usecase.NewEmailUsecase(emailRepo, workerClient)
 	userUsecase := usecase.NewUserUsecase(userRepo, pinRepo, sharedCryptor, emailUsecase, accessTokenRepo, db.PostgresDB)
-	authUsecase := usecase.NewAuthUsecase(accessTokenRepo, userRepo, sharedCryptor)
+	authUsecase := usecase.NewAuthUsecase(accessTokenRepo, userRepo, sharedCryptor, workerClient)
 	sdtemplateUsecase := usecase.NewSDTemplateUsecase(sdtemplateRepo)
 	sdpackageUsecase := usecase.NewSDPackageUsecase(sdpackageRepo, sdtemplateRepo)
 	sdtUsecase := usecase.NewSDTestResultUsecase(sdtRepo, sdpackageRepo, sharedCryptor, db.PostgresDB, f)

--- a/internal/db/cacher.go
+++ b/internal/db/cacher.go
@@ -51,3 +51,12 @@ func (c *cacher) Set(ctx context.Context, key string, val string, exp time.Durat
 
 	return nil
 }
+
+func (c *cacher) Del(ctx context.Context, key []string) error {
+	err := c.client.Del(ctx, key...).Err()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/model/auth.go
+++ b/internal/model/auth.go
@@ -132,8 +132,11 @@ type AccessTokenRepository interface {
 	Create(ctx context.Context, at *AccessToken) error
 	FindByToken(ctx context.Context, token string) (*AccessToken, error)
 	DeleteByID(ctx context.Context, id uuid.UUID) error
+	DeleteByIDs(ctx context.Context, ids []uuid.UUID, hardDelete bool) error
 	FindCredentialByToken(ctx context.Context, token string) (*AccessToken, *User, error)
 	DeleteByUserID(ctx context.Context, id uuid.UUID, tx *gorm.DB) error
+	FindByUserID(ctx context.Context, userID uuid.UUID, limit int) ([]AccessToken, error)
+	DeleteCredentialsFromCache(ctx context.Context, tokens []string) error
 }
 
 // AuthUsecase auth usecase

--- a/internal/model/cacher.go
+++ b/internal/model/cacher.go
@@ -13,4 +13,5 @@ const NilKey = "NIL"
 type Cacher interface {
 	Get(ctx context.Context, key string) (string, error)
 	Set(ctx context.Context, key string, value string, exp time.Duration) error
+	Del(ctx context.Context, key []string) error
 }

--- a/internal/model/mock/mock_access_token_repository.go
+++ b/internal/model/mock/mock_access_token_repository.go
@@ -65,6 +65,20 @@ func (mr *MockAccessTokenRepositoryMockRecorder) DeleteByID(arg0, arg1 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByID", reflect.TypeOf((*MockAccessTokenRepository)(nil).DeleteByID), arg0, arg1)
 }
 
+// DeleteByIDs mocks base method.
+func (m *MockAccessTokenRepository) DeleteByIDs(arg0 context.Context, arg1 []uuid.UUID, arg2 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteByIDs", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteByIDs indicates an expected call of DeleteByIDs.
+func (mr *MockAccessTokenRepositoryMockRecorder) DeleteByIDs(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByIDs", reflect.TypeOf((*MockAccessTokenRepository)(nil).DeleteByIDs), arg0, arg1, arg2)
+}
+
 // DeleteByUserID mocks base method.
 func (m *MockAccessTokenRepository) DeleteByUserID(arg0 context.Context, arg1 uuid.UUID, arg2 *gorm.DB) error {
 	m.ctrl.T.Helper()
@@ -77,6 +91,20 @@ func (m *MockAccessTokenRepository) DeleteByUserID(arg0 context.Context, arg1 uu
 func (mr *MockAccessTokenRepositoryMockRecorder) DeleteByUserID(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByUserID", reflect.TypeOf((*MockAccessTokenRepository)(nil).DeleteByUserID), arg0, arg1, arg2)
+}
+
+// DeleteCredentialsFromCache mocks base method.
+func (m *MockAccessTokenRepository) DeleteCredentialsFromCache(arg0 context.Context, arg1 []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCredentialsFromCache", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCredentialsFromCache indicates an expected call of DeleteCredentialsFromCache.
+func (mr *MockAccessTokenRepositoryMockRecorder) DeleteCredentialsFromCache(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCredentialsFromCache", reflect.TypeOf((*MockAccessTokenRepository)(nil).DeleteCredentialsFromCache), arg0, arg1)
 }
 
 // FindByToken mocks base method.
@@ -92,6 +120,21 @@ func (m *MockAccessTokenRepository) FindByToken(arg0 context.Context, arg1 strin
 func (mr *MockAccessTokenRepositoryMockRecorder) FindByToken(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByToken", reflect.TypeOf((*MockAccessTokenRepository)(nil).FindByToken), arg0, arg1)
+}
+
+// FindByUserID mocks base method.
+func (m *MockAccessTokenRepository) FindByUserID(arg0 context.Context, arg1 uuid.UUID, arg2 int) ([]model.AccessToken, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindByUserID", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]model.AccessToken)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindByUserID indicates an expected call of FindByUserID.
+func (mr *MockAccessTokenRepositoryMockRecorder) FindByUserID(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByUserID", reflect.TypeOf((*MockAccessTokenRepository)(nil).FindByUserID), arg0, arg1, arg2)
 }
 
 // FindCredentialByToken mocks base method.

--- a/internal/model/mock/mock_cacher.go
+++ b/internal/model/mock/mock_cacher.go
@@ -35,6 +35,20 @@ func (m *MockCacher) EXPECT() *MockCacherMockRecorder {
 	return m.recorder
 }
 
+// Del mocks base method.
+func (m *MockCacher) Del(arg0 context.Context, arg1 []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Del", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Del indicates an expected call of Del.
+func (mr *MockCacherMockRecorder) Del(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Del", reflect.TypeOf((*MockCacher)(nil).Del), arg0, arg1)
+}
+
 // Get mocks base method.
 func (m *MockCacher) Get(arg0 context.Context, arg1 string) (string, error) {
 	m.ctrl.T.Helper()

--- a/internal/model/mock/mock_worker_client.go
+++ b/internal/model/mock/mock_worker_client.go
@@ -36,19 +36,19 @@ func (m *MockWorkerClient) EXPECT() *MockWorkerClientMockRecorder {
 	return m.recorder
 }
 
-// EnqueueEnforceActiveTokenLimitterTask mocks base method.
-func (m *MockWorkerClient) EnqueueEnforceActiveTokenLimitterTask(arg0 context.Context, arg1 uuid.UUID) (*asynq.TaskInfo, error) {
+// EnqueueEnforceActiveTokenLimiterTask mocks base method.
+func (m *MockWorkerClient) EnqueueEnforceActiveTokenLimiterTask(arg0 context.Context, arg1 uuid.UUID) (*asynq.TaskInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnqueueEnforceActiveTokenLimitterTask", arg0, arg1)
+	ret := m.ctrl.Call(m, "EnqueueEnforceActiveTokenLimiterTask", arg0, arg1)
 	ret0, _ := ret[0].(*asynq.TaskInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// EnqueueEnforceActiveTokenLimitterTask indicates an expected call of EnqueueEnforceActiveTokenLimitterTask.
-func (mr *MockWorkerClientMockRecorder) EnqueueEnforceActiveTokenLimitterTask(arg0, arg1 interface{}) *gomock.Call {
+// EnqueueEnforceActiveTokenLimiterTask indicates an expected call of EnqueueEnforceActiveTokenLimiterTask.
+func (mr *MockWorkerClientMockRecorder) EnqueueEnforceActiveTokenLimiterTask(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueEnforceActiveTokenLimitterTask", reflect.TypeOf((*MockWorkerClient)(nil).EnqueueEnforceActiveTokenLimitterTask), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueEnforceActiveTokenLimiterTask", reflect.TypeOf((*MockWorkerClient)(nil).EnqueueEnforceActiveTokenLimiterTask), arg0, arg1)
 }
 
 // EnqueueSendEmailTask mocks base method.

--- a/internal/model/mock/mock_worker_client.go
+++ b/internal/model/mock/mock_worker_client.go
@@ -36,6 +36,21 @@ func (m *MockWorkerClient) EXPECT() *MockWorkerClientMockRecorder {
 	return m.recorder
 }
 
+// EnqueueEnforceActiveTokenLimitterTask mocks base method.
+func (m *MockWorkerClient) EnqueueEnforceActiveTokenLimitterTask(arg0 context.Context, arg1 uuid.UUID) (*asynq.TaskInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnqueueEnforceActiveTokenLimitterTask", arg0, arg1)
+	ret0, _ := ret[0].(*asynq.TaskInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnqueueEnforceActiveTokenLimitterTask indicates an expected call of EnqueueEnforceActiveTokenLimitterTask.
+func (mr *MockWorkerClientMockRecorder) EnqueueEnforceActiveTokenLimitterTask(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueEnforceActiveTokenLimitterTask", reflect.TypeOf((*MockWorkerClient)(nil).EnqueueEnforceActiveTokenLimitterTask), arg0, arg1)
+}
+
 // EnqueueSendEmailTask mocks base method.
 func (m *MockWorkerClient) EnqueueSendEmailTask(arg0 context.Context, arg1 uuid.UUID) (*asynq.TaskInfo, error) {
 	m.ctrl.T.Helper()

--- a/internal/model/worker.go
+++ b/internal/model/worker.go
@@ -12,12 +12,12 @@ type Task string
 
 // list of all available task
 const (
-	TaskSendEmail                  Task = "ATEC-API:sendEmail"
-	TaskEnforceActiveTokenLimitter Task = "ATEC-API:enforceActiveTokenLImitter"
+	TaskSendEmail                 Task = "ATEC-API:sendEmail"
+	TaskEnforceActiveTokenLimiter Task = "ATEC-API:enforceActiveTokenLImiter"
 )
 
 // WorkerClient is the interface for all worker client mainly to enqueue task
 type WorkerClient interface {
 	EnqueueSendEmailTask(ctx context.Context, id uuid.UUID) (*asynq.TaskInfo, error)
-	EnqueueEnforceActiveTokenLimitterTask(ctx context.Context, userID uuid.UUID) (*asynq.TaskInfo, error)
+	EnqueueEnforceActiveTokenLimiterTask(ctx context.Context, userID uuid.UUID) (*asynq.TaskInfo, error)
 }

--- a/internal/model/worker.go
+++ b/internal/model/worker.go
@@ -12,10 +12,12 @@ type Task string
 
 // list of all available task
 const (
-	TaskSendEmail Task = "ATEC-API:sendEmail"
+	TaskSendEmail                  Task = "ATEC-API:sendEmail"
+	TaskEnforceActiveTokenLimitter Task = "ATEC-API:enforceActiveTokenLImitter"
 )
 
 // WorkerClient is the interface for all worker client mainly to enqueue task
 type WorkerClient interface {
 	EnqueueSendEmailTask(ctx context.Context, id uuid.UUID) (*asynq.TaskInfo, error)
+	EnqueueEnforceActiveTokenLimitterTask(ctx context.Context, userID uuid.UUID) (*asynq.TaskInfo, error)
 }

--- a/internal/usecase/auth.go
+++ b/internal/usecase/auth.go
@@ -137,7 +137,7 @@ func (u *authUc) LogIn(ctx context.Context, input *model.LogInInput) (*model.Log
 		}
 	}
 
-	if err := u.registerActiveTokenLimitterTask(ctx, user.ID); err != nil {
+	if err := u.registerActiveTokenLimiterTask(ctx, user.ID); err != nil {
 		logger.WithError(err).Error("failed to enqueue enforce active token limiter task")
 	}
 
@@ -391,13 +391,13 @@ func (u *authUc) ResetPassword(ctx context.Context, input *model.ResetPasswordIn
 	}, nilErr
 }
 
-func (u *authUc) registerActiveTokenLimitterTask(ctx context.Context, userID uuid.UUID) error {
+func (u *authUc) registerActiveTokenLimiterTask(ctx context.Context, userID uuid.UUID) error {
 	// early return if not needed
 	if config.ActiveTokenLimit() <= 0 {
 		return nil
 	}
 
-	_, err := u.workerClient.EnqueueEnforceActiveTokenLimitterTask(ctx, userID)
+	_, err := u.workerClient.EnqueueEnforceActiveTokenLimiterTask(ctx, userID)
 	if err != nil {
 		return err
 	}

--- a/internal/usecase/auth.go
+++ b/internal/usecase/auth.go
@@ -21,14 +21,16 @@ type authUc struct {
 	accessTokenRepo model.AccessTokenRepository
 	userRepo        model.UserRepository
 	sharedCryptor   common.SharedCryptor
+	workerClient    model.WorkerClient
 }
 
 // NewAuthUsecase returns a new AuthUsecase
-func NewAuthUsecase(accessTokenRepo model.AccessTokenRepository, userRepo model.UserRepository, sharedCryptor common.SharedCryptor) model.AuthUsecase {
+func NewAuthUsecase(accessTokenRepo model.AccessTokenRepository, userRepo model.UserRepository, sharedCryptor common.SharedCryptor, workerClient model.WorkerClient) model.AuthUsecase {
 	return &authUc{
 		accessTokenRepo: accessTokenRepo,
 		userRepo:        userRepo,
 		sharedCryptor:   sharedCryptor,
+		workerClient:    workerClient,
 	}
 }
 
@@ -133,6 +135,10 @@ func (u *authUc) LogIn(ctx context.Context, input *model.LogInInput) (*model.Log
 			Code:    http.StatusInternalServerError,
 			Type:    ErrInternal,
 		}
+	}
+
+	if err := u.registerActiveTokenLimitterTask(ctx, user.ID); err != nil {
+		logger.WithError(err).Error("failed to enqueue enforce active token limiter task")
 	}
 
 	return at.ToLogInOutput(plain), nilErr
@@ -383,4 +389,18 @@ func (u *authUc) ResetPassword(ctx context.Context, input *model.ResetPasswordIn
 		UpdatedAt: user.UpdatedAt,
 		DeletedAt: null.NewTime(user.DeletedAt.Time, user.DeletedAt.Valid),
 	}, nilErr
+}
+
+func (u *authUc) registerActiveTokenLimitterTask(ctx context.Context, userID uuid.UUID) error {
+	// early return if not needed
+	if config.ActiveTokenLimit() <= 0 {
+		return nil
+	}
+
+	_, err := u.workerClient.EnqueueEnforceActiveTokenLimitterTask(ctx, userID)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/usecase/auth_test.go
+++ b/internal/usecase/auth_test.go
@@ -212,7 +212,7 @@ func TestAuthUsecase_LogIn(t *testing.T) {
 				mockSharedCryptor.EXPECT().CompareHash(pwDecoded, []byte(input.Password)).Times(1).Return(nil)
 				mockSharedCryptor.EXPECT().CreateSecureToken().Times(1).Return("plain", "crypted", nil)
 				mockAccessTokenRepo.EXPECT().Create(ctx, gomock.Any()).Times(1).Return(nil)
-				mockWorkerClient.EXPECT().EnqueueEnforceActiveTokenLimitterTask(ctx, user.ID).Times(1).Return(&asynq.TaskInfo{}, nil)
+				mockWorkerClient.EXPECT().EnqueueEnforceActiveTokenLimiterTask(ctx, user.ID).Times(1).Return(&asynq.TaskInfo{}, nil)
 			},
 			Run: func() {
 				viper.Set("server.auth.active_token_limit", 10)
@@ -230,7 +230,7 @@ func TestAuthUsecase_LogIn(t *testing.T) {
 				mockSharedCryptor.EXPECT().CompareHash(pwDecoded, []byte(input.Password)).Times(1).Return(nil)
 				mockSharedCryptor.EXPECT().CreateSecureToken().Times(1).Return("plain", "crypted", nil)
 				mockAccessTokenRepo.EXPECT().Create(ctx, gomock.Any()).Times(1).Return(nil)
-				mockWorkerClient.EXPECT().EnqueueEnforceActiveTokenLimitterTask(ctx, user.ID).Times(1).Return(nil, errors.New("err worker"))
+				mockWorkerClient.EXPECT().EnqueueEnforceActiveTokenLimiterTask(ctx, user.ID).Times(1).Return(nil, errors.New("err worker"))
 			},
 			Run: func() {
 				viper.Set("server.auth.active_token_limit", 10)
@@ -248,7 +248,7 @@ func TestAuthUsecase_LogIn(t *testing.T) {
 				mockSharedCryptor.EXPECT().CompareHash(pwDecoded, []byte(input.Password)).Times(1).Return(nil)
 				mockSharedCryptor.EXPECT().CreateSecureToken().Times(1).Return("plain", "crypted", nil)
 				mockAccessTokenRepo.EXPECT().Create(ctx, gomock.Any()).Times(1).Return(nil)
-				//mockWorkerClient.EXPECT().EnqueueEnforceActiveTokenLimitterTask(ctx, user.ID).Times(1).Return(&asynq.TaskInfo{}, nil)
+				//mockWorkerClient.EXPECT().EnqueueEnforceActiveTokenLimiterTask(ctx, user.ID).Times(1).Return(&asynq.TaskInfo{}, nil)
 			},
 			Run: func() {
 				viper.Set("server.auth.active_token_limit", 0)

--- a/internal/usecase/auth_test.go
+++ b/internal/usecase/auth_test.go
@@ -10,11 +10,13 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
+	"github.com/hibiken/asynq"
 	"github.com/luckyAkbar/atec-api/internal/common"
 	commonMock "github.com/luckyAkbar/atec-api/internal/common/mock"
 	"github.com/luckyAkbar/atec-api/internal/model"
 	"github.com/luckyAkbar/atec-api/internal/model/mock"
 	"github.com/luckyAkbar/atec-api/internal/repository"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 )
@@ -25,8 +27,9 @@ func TestAuthUsecase_LogIn(t *testing.T) {
 	mockAccessTokenRepo := mock.NewMockAccessTokenRepository(ctrl)
 	mockUserRepo := mock.NewMockUserRepository(ctrl)
 	mockSharedCryptor := commonMock.NewMockSharedCryptor(ctrl)
+	mockWorkerClient := mock.NewMockWorkerClient(ctrl)
 
-	uc := NewAuthUsecase(mockAccessTokenRepo, mockUserRepo, mockSharedCryptor)
+	uc := NewAuthUsecase(mockAccessTokenRepo, mockUserRepo, mockSharedCryptor, mockWorkerClient)
 
 	input := &model.LogInInput{
 		Email:    "valid.email@format.com",
@@ -209,8 +212,46 @@ func TestAuthUsecase_LogIn(t *testing.T) {
 				mockSharedCryptor.EXPECT().CompareHash(pwDecoded, []byte(input.Password)).Times(1).Return(nil)
 				mockSharedCryptor.EXPECT().CreateSecureToken().Times(1).Return("plain", "crypted", nil)
 				mockAccessTokenRepo.EXPECT().Create(ctx, gomock.Any()).Times(1).Return(nil)
+				mockWorkerClient.EXPECT().EnqueueEnforceActiveTokenLimitterTask(ctx, user.ID).Times(1).Return(&asynq.TaskInfo{}, nil)
 			},
 			Run: func() {
+				viper.Set("server.auth.active_token_limit", 10)
+				resp, cerr := uc.LogIn(ctx, input)
+
+				assert.NoError(t, cerr.Type)
+				assert.Equal(t, resp.UserID, user.ID)
+			},
+		},
+		{
+			Name: "failed to enqueue enforce active token limiter, but thats ok",
+			MockFn: func() {
+				mockSharedCryptor.EXPECT().Encrypt(input.Email).Times(1).Return(encEmail, nil)
+				mockUserRepo.EXPECT().FindByEmail(ctx, encEmail).Times(1).Return(user, nil)
+				mockSharedCryptor.EXPECT().CompareHash(pwDecoded, []byte(input.Password)).Times(1).Return(nil)
+				mockSharedCryptor.EXPECT().CreateSecureToken().Times(1).Return("plain", "crypted", nil)
+				mockAccessTokenRepo.EXPECT().Create(ctx, gomock.Any()).Times(1).Return(nil)
+				mockWorkerClient.EXPECT().EnqueueEnforceActiveTokenLimitterTask(ctx, user.ID).Times(1).Return(nil, errors.New("err worker"))
+			},
+			Run: func() {
+				viper.Set("server.auth.active_token_limit", 10)
+				resp, cerr := uc.LogIn(ctx, input)
+
+				assert.NoError(t, cerr.Type)
+				assert.Equal(t, resp.UserID, user.ID)
+			},
+		},
+		{
+			Name: "ok-active token limiter is disabled",
+			MockFn: func() {
+				mockSharedCryptor.EXPECT().Encrypt(input.Email).Times(1).Return(encEmail, nil)
+				mockUserRepo.EXPECT().FindByEmail(ctx, encEmail).Times(1).Return(user, nil)
+				mockSharedCryptor.EXPECT().CompareHash(pwDecoded, []byte(input.Password)).Times(1).Return(nil)
+				mockSharedCryptor.EXPECT().CreateSecureToken().Times(1).Return("plain", "crypted", nil)
+				mockAccessTokenRepo.EXPECT().Create(ctx, gomock.Any()).Times(1).Return(nil)
+				//mockWorkerClient.EXPECT().EnqueueEnforceActiveTokenLimitterTask(ctx, user.ID).Times(1).Return(&asynq.TaskInfo{}, nil)
+			},
+			Run: func() {
+				viper.Set("server.auth.active_token_limit", 0)
 				resp, cerr := uc.LogIn(ctx, input)
 
 				assert.NoError(t, cerr.Type)
@@ -233,8 +274,9 @@ func TestAuthUsecase_LogOut(t *testing.T) {
 	mockAccessTokenRepo := mock.NewMockAccessTokenRepository(ctrl)
 	mockUserRepo := mock.NewMockUserRepository(ctrl)
 	mockSharedCryptor := commonMock.NewMockSharedCryptor(ctrl)
+	mockWorkerClient := mock.NewMockWorkerClient(ctrl)
 
-	uc := NewAuthUsecase(mockAccessTokenRepo, mockUserRepo, mockSharedCryptor)
+	uc := NewAuthUsecase(mockAccessTokenRepo, mockUserRepo, mockSharedCryptor, mockWorkerClient)
 	tokenEnc := "encrypted token"
 	token := &model.AccessToken{
 		ID:    uuid.New(),
@@ -314,8 +356,9 @@ func TestAuthUsecase_ValidateAccess(t *testing.T) {
 	mockAccessTokenRepo := mock.NewMockAccessTokenRepository(ctrl)
 	mockUserRepo := mock.NewMockUserRepository(ctrl)
 	mockSharedCryptor := commonMock.NewMockSharedCryptor(ctrl)
+	mockWorkerClient := mock.NewMockWorkerClient(ctrl)
 
-	uc := NewAuthUsecase(mockAccessTokenRepo, mockUserRepo, mockSharedCryptor)
+	uc := NewAuthUsecase(mockAccessTokenRepo, mockUserRepo, mockSharedCryptor, mockWorkerClient)
 	token := "token"
 	revToken := "rev token"
 	user := &model.User{
@@ -413,8 +456,9 @@ func TestAuthUsecase_ValidateResetPasswordSession(t *testing.T) {
 	mockAccessTokenRepo := mock.NewMockAccessTokenRepository(ctrl)
 	mockUserRepo := mock.NewMockUserRepository(ctrl)
 	mockSharedCryptor := commonMock.NewMockSharedCryptor(ctrl)
+	mockWorkerClient := mock.NewMockWorkerClient(ctrl)
 
-	uc := NewAuthUsecase(mockAccessTokenRepo, mockUserRepo, mockSharedCryptor)
+	uc := NewAuthUsecase(mockAccessTokenRepo, mockUserRepo, mockSharedCryptor, mockWorkerClient)
 	key := "key"
 	session := &model.ChangePasswordSession{
 		UserID:    uuid.New(),
@@ -498,8 +542,9 @@ func TestAuthUsecase_ResetPassword(t *testing.T) {
 	mockAccessTokenRepo := mock.NewMockAccessTokenRepository(ctrl)
 	mockUserRepo := mock.NewMockUserRepository(ctrl)
 	mockSharedCryptor := commonMock.NewMockSharedCryptor(ctrl)
+	mockWorkerClient := mock.NewMockWorkerClient(ctrl)
 
-	uc := NewAuthUsecase(mockAccessTokenRepo, mockUserRepo, mockSharedCryptor)
+	uc := NewAuthUsecase(mockAccessTokenRepo, mockUserRepo, mockSharedCryptor, mockWorkerClient)
 	input := &model.ResetPasswordInput{
 		Key:                 "valid key oke",
 		Password:            "validpassword",

--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -45,21 +45,21 @@ func (c *client) EnqueueSendEmailTask(ctx context.Context, id uuid.UUID) (*asynq
 	return info, nil
 }
 
-func (c *client) EnqueueEnforceActiveTokenLimitterTask(ctx context.Context, userID uuid.UUID) (*asynq.TaskInfo, error) {
+func (c *client) EnqueueEnforceActiveTokenLimiterTask(ctx context.Context, userID uuid.UUID) (*asynq.TaskInfo, error) {
 	logger := logrus.WithContext(ctx).WithFields(logrus.Fields{
-		"func":  "client.EnqueueEnforceActiveTokenLimitterTask",
+		"func":  "client.EnqueueEnforceActiveTokenLimiterTask",
 		"input": helper.Dump(userID),
 	})
 
 	payload, err := json.Marshal(userID)
 	if err != nil {
-		logger.WithError(err).Error("failed to marshal payload for enqueue enforce active token limitter task")
+		logger.WithError(err).Error("failed to marshal payload for enqueue enforce active token limiter task")
 		return nil, err
 	}
 
 	info, err := c.workerClient.EnqueueTask(ctx,
 		asynq.NewTask(
-			string(model.TaskEnforceActiveTokenLimitter),
+			string(model.TaskEnforceActiveTokenLimiter),
 			payload,
 			asynq.Queue(string(workerPkg.PriorityHigh))))
 

--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -44,3 +44,29 @@ func (c *client) EnqueueSendEmailTask(ctx context.Context, id uuid.UUID) (*asynq
 
 	return info, nil
 }
+
+func (c *client) EnqueueEnforceActiveTokenLimitterTask(ctx context.Context, userID uuid.UUID) (*asynq.TaskInfo, error) {
+	logger := logrus.WithContext(ctx).WithFields(logrus.Fields{
+		"func":  "client.EnqueueEnforceActiveTokenLimitterTask",
+		"input": helper.Dump(userID),
+	})
+
+	payload, err := json.Marshal(userID)
+	if err != nil {
+		logger.WithError(err).Error("failed to marshal payload for enqueue enforce active token limitter task")
+		return nil, err
+	}
+
+	info, err := c.workerClient.EnqueueTask(ctx,
+		asynq.NewTask(
+			string(model.TaskEnforceActiveTokenLimitter),
+			payload,
+			asynq.Queue(string(workerPkg.PriorityHigh))))
+
+	if err != nil {
+		logger.WithError(err).Error("failed to enqueue task")
+		return nil, err
+	}
+
+	return info, nil
+}

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -12,15 +12,18 @@ var mux = asynq.NewServeMux()
 
 func registerTaskHandler(taskHandler *th) {
 	mux.HandleFunc(string(model.TaskSendEmail), taskHandler.HandleSendEmail)
+	mux.HandleFunc(string(model.TaskEnforceActiveTokenLimitter), taskHandler.HandleEnforceActiveTokenLimitter)
 }
 
 // ServerConfig configuration options for worker server
 type ServerConfig struct {
-	AsynqConfig   asynq.Config
-	SchedulerOpts *asynq.SchedulerOpts
-	MailUtil      mail.Utility
-	Limiter       *rate.Limiter
-	MailRepo      model.EmailRepository
+	AsynqConfig     asynq.Config
+	SchedulerOpts   *asynq.SchedulerOpts
+	MailUtil        mail.Utility
+	Limiter         *rate.Limiter
+	MailRepo        model.EmailRepository
+	UserRepo        model.UserRepository
+	AccessTokenRepo model.AccessTokenRepository
 }
 
 // NewServer return worker server
@@ -31,7 +34,7 @@ func NewServer(redisHost string, cfg ServerConfig) (workerPkg.Server, error) {
 		cfg.SchedulerOpts,
 	)
 
-	th := newTaskHandler(cfg.MailUtil, cfg.Limiter, cfg.MailRepo)
+	th := newTaskHandler(cfg.MailUtil, cfg.Limiter, cfg.MailRepo, cfg.UserRepo, cfg.AccessTokenRepo)
 
 	registerTaskHandler(th)
 

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -12,7 +12,7 @@ var mux = asynq.NewServeMux()
 
 func registerTaskHandler(taskHandler *th) {
 	mux.HandleFunc(string(model.TaskSendEmail), taskHandler.HandleSendEmail)
-	mux.HandleFunc(string(model.TaskEnforceActiveTokenLimitter), taskHandler.HandleEnforceActiveTokenLimitter)
+	mux.HandleFunc(string(model.TaskEnforceActiveTokenLimiter), taskHandler.HandleEnforceActiveTokenLimiter)
 }
 
 // ServerConfig configuration options for worker server

--- a/internal/worker/task_handler.go
+++ b/internal/worker/task_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sort"
 	"time"
 
 	"github.com/google/uuid"
@@ -20,16 +21,20 @@ import (
 )
 
 type th struct {
-	mailUtil mail.Utility
-	limiter  *rate.Limiter
-	mailRepo model.EmailRepository
+	mailUtil        mail.Utility
+	limiter         *rate.Limiter
+	mailRepo        model.EmailRepository
+	userRepo        model.UserRepository
+	accessTokenRepo model.AccessTokenRepository
 }
 
-func newTaskHandler(mailUtil mail.Utility, limiter *rate.Limiter, mailRepo model.EmailRepository) *th {
+func newTaskHandler(mailUtil mail.Utility, limiter *rate.Limiter, mailRepo model.EmailRepository, userRepo model.UserRepository, accessTokenRepo model.AccessTokenRepository) *th {
 	return &th{
-		mailUtil: mailUtil,
-		limiter:  limiter,
-		mailRepo: mailRepo,
+		mailUtil:        mailUtil,
+		limiter:         limiter,
+		mailRepo:        mailRepo,
+		accessTokenRepo: accessTokenRepo,
+		userRepo:        userRepo,
 	}
 }
 
@@ -95,6 +100,77 @@ func (th *th) HandleSendEmail(ctx context.Context, task *asynq.Task) error {
 
 	if err := th.mailRepo.Update(ctx, email); err != nil {
 		logger.WithError(err).Error("failed to update email after successfully sent it, not marking as failure")
+	}
+
+	return nil
+}
+
+func (th *th) HandleEnforceActiveTokenLimitter(ctx context.Context, task *asynq.Task) error {
+	logger := logrus.WithContext(ctx).WithFields(logrus.Fields{
+		"func":    "taskHandler.HandleEnforceActiveTokenLimitter",
+		"payload": string(task.Payload()),
+	})
+
+	var userID uuid.UUID
+	if err := json.Unmarshal(task.Payload(), &userID); err != nil {
+		logger.WithError(err).Error("failed to unmarshal payload for send email")
+		return err
+	}
+
+	if !th.limiter.Allow() {
+		logger.WithField("userID", userID).Warn("rate limit exceeded for task: ", task.Type())
+		return newWorkerRateLimitError()
+	}
+
+	user, err := th.userRepo.FindByID(ctx, userID)
+	switch err {
+	default:
+		logger.WithError(err).Error("failed to fetch user data")
+		return err
+	case repository.ErrNotFound:
+		logger.WithError(err).Error("user data not found on database thus unable to perform task and will not be retried")
+		return nil
+	case nil:
+		break
+	}
+
+	accessTokens, err := th.accessTokenRepo.FindByUserID(ctx, user.ID, config.ActiveTokenLimit()*2)
+	switch err {
+	default:
+		logger.WithError(err).Error("failed to fetch access token data")
+		return err
+	case repository.ErrNotFound:
+		logger.WithField("userID", userID).Info("no access token found for this userID, thus marked as success")
+		return nil
+	case nil:
+		break
+	}
+
+	if len(accessTokens) <= config.ActiveTokenLimit() {
+		logger.WithField("userID", user.ID).Info("this user still doesn't have exceed active token limit")
+		return nil
+	}
+
+	// sort ascending, where the result will be sorted by created_at asc
+	sort.SliceStable(accessTokens, func(i, j int) bool {
+		return accessTokens[i].CreatedAt.Before(accessTokens[j].CreatedAt)
+	})
+
+	idsToDelete := []uuid.UUID{}
+	tokensToDelete := []string{}
+	for i := 0; i < len(accessTokens)-config.ActiveTokenLimit(); i++ {
+		idsToDelete = append(idsToDelete, accessTokens[i].ID)
+		tokensToDelete = append(tokensToDelete, accessTokens[i].Token)
+	}
+
+	if err := th.accessTokenRepo.DeleteCredentialsFromCache(ctx, tokensToDelete); err != nil {
+		logger.WithError(err).Error("failed to delete credentials from cache")
+		return err
+	}
+
+	if err := th.accessTokenRepo.DeleteByIDs(ctx, idsToDelete, true); err != nil {
+		logger.WithError(err).Error("failed to batch delete exceeding access token")
+		return err
 	}
 
 	return nil

--- a/internal/worker/task_handler.go
+++ b/internal/worker/task_handler.go
@@ -105,9 +105,9 @@ func (th *th) HandleSendEmail(ctx context.Context, task *asynq.Task) error {
 	return nil
 }
 
-func (th *th) HandleEnforceActiveTokenLimitter(ctx context.Context, task *asynq.Task) error {
+func (th *th) HandleEnforceActiveTokenLimiter(ctx context.Context, task *asynq.Task) error {
 	logger := logrus.WithContext(ctx).WithFields(logrus.Fields{
-		"func":    "taskHandler.HandleEnforceActiveTokenLimitter",
+		"func":    "taskHandler.HandleEnforceActiveTokenLimiter",
 		"payload": string(task.Payload()),
 	})
 

--- a/internal/worker/task_handler_test.go
+++ b/internal/worker/task_handler_test.go
@@ -205,7 +205,7 @@ func TestTaskHandler_HandleEnforceActiveTokenLimiter(t *testing.T) {
 	payload, err := json.Marshal(id)
 	assert.NoError(t, err)
 
-	task := asynq.NewTask(string(model.TaskEnforceActiveTokenLimitter), payload)
+	task := asynq.NewTask(string(model.TaskEnforceActiveTokenLimiter), payload)
 
 	th := newTaskHandler(mockMailUtility, normalLimiter, mockMailRepo, mockUserRepo, mockAccessTokenRepo)
 
@@ -239,8 +239,8 @@ func TestTaskHandler_HandleEnforceActiveTokenLimiter(t *testing.T) {
 			Name:   "invalid payload -> failed to unmarshal",
 			MockFn: func() {},
 			Run: func() {
-				_task := asynq.NewTask(string(model.TaskEnforceActiveTokenLimitter), []byte("][=-098765321234567890]["))
-				err := th.HandleEnforceActiveTokenLimitter(ctx, _task)
+				_task := asynq.NewTask(string(model.TaskEnforceActiveTokenLimiter), []byte("][=-098765321234567890]["))
+				err := th.HandleEnforceActiveTokenLimiter(ctx, _task)
 
 				assert.Error(t, err)
 				assert.Equal(t, err.Error(), "invalid character ']' looking for beginning of value")
@@ -252,7 +252,7 @@ func TestTaskHandler_HandleEnforceActiveTokenLimiter(t *testing.T) {
 			Run: func() {
 				rateLimited := rate.NewLimiter(0, 0)
 				rlTaskHandler := newTaskHandler(mockMailUtility, rateLimited, mockMailRepo, mockUserRepo, mockAccessTokenRepo)
-				err := rlTaskHandler.HandleEnforceActiveTokenLimitter(ctx, task)
+				err := rlTaskHandler.HandleEnforceActiveTokenLimiter(ctx, task)
 				assert.Error(t, err)
 
 				assert.Equal(t, err, newWorkerRateLimitError())
@@ -264,7 +264,7 @@ func TestTaskHandler_HandleEnforceActiveTokenLimiter(t *testing.T) {
 				mockUserRepo.EXPECT().FindByID(ctx, id).Times(1).Return(nil, errors.New("err db"))
 			},
 			Run: func() {
-				err := th.HandleEnforceActiveTokenLimitter(ctx, task)
+				err := th.HandleEnforceActiveTokenLimiter(ctx, task)
 				assert.Error(t, err)
 			},
 		},
@@ -274,7 +274,7 @@ func TestTaskHandler_HandleEnforceActiveTokenLimiter(t *testing.T) {
 				mockUserRepo.EXPECT().FindByID(ctx, id).Times(1).Return(nil, repository.ErrNotFound)
 			},
 			Run: func() {
-				err := th.HandleEnforceActiveTokenLimitter(ctx, task)
+				err := th.HandleEnforceActiveTokenLimiter(ctx, task)
 				assert.NoError(t, err)
 			},
 		},
@@ -285,7 +285,7 @@ func TestTaskHandler_HandleEnforceActiveTokenLimiter(t *testing.T) {
 				mockAccessTokenRepo.EXPECT().FindByUserID(ctx, user.ID, activeTokenLimit*2).Times(1).Return(nil, errors.New("err db"))
 			},
 			Run: func() {
-				err := th.HandleEnforceActiveTokenLimitter(ctx, task)
+				err := th.HandleEnforceActiveTokenLimiter(ctx, task)
 				assert.Error(t, err)
 			},
 		},
@@ -296,7 +296,7 @@ func TestTaskHandler_HandleEnforceActiveTokenLimiter(t *testing.T) {
 				mockAccessTokenRepo.EXPECT().FindByUserID(ctx, user.ID, activeTokenLimit*2).Times(1).Return(nil, repository.ErrNotFound)
 			},
 			Run: func() {
-				err := th.HandleEnforceActiveTokenLimitter(ctx, task)
+				err := th.HandleEnforceActiveTokenLimiter(ctx, task)
 				assert.NoError(t, err)
 			},
 		},
@@ -307,7 +307,7 @@ func TestTaskHandler_HandleEnforceActiveTokenLimiter(t *testing.T) {
 				mockAccessTokenRepo.EXPECT().FindByUserID(ctx, user.ID, activeTokenLimit*2).Times(1).Return(belowLimitAccessToken, nil)
 			},
 			Run: func() {
-				err := th.HandleEnforceActiveTokenLimitter(ctx, task)
+				err := th.HandleEnforceActiveTokenLimiter(ctx, task)
 				assert.NoError(t, err)
 			},
 		},
@@ -319,7 +319,7 @@ func TestTaskHandler_HandleEnforceActiveTokenLimiter(t *testing.T) {
 				mockAccessTokenRepo.EXPECT().DeleteCredentialsFromCache(ctx, []string{tobeDeletedAccessToken.Token}).Times(1).Return(errors.New("err redis"))
 			},
 			Run: func() {
-				err := th.HandleEnforceActiveTokenLimitter(ctx, task)
+				err := th.HandleEnforceActiveTokenLimiter(ctx, task)
 				assert.Error(t, err)
 			},
 		},
@@ -332,7 +332,7 @@ func TestTaskHandler_HandleEnforceActiveTokenLimiter(t *testing.T) {
 				mockAccessTokenRepo.EXPECT().DeleteByIDs(ctx, []uuid.UUID{tobeDeletedAccessToken.ID}, true).Times(1).Return(errors.New("err db"))
 			},
 			Run: func() {
-				err := th.HandleEnforceActiveTokenLimitter(ctx, task)
+				err := th.HandleEnforceActiveTokenLimiter(ctx, task)
 				assert.Error(t, err)
 			},
 		},
@@ -345,7 +345,7 @@ func TestTaskHandler_HandleEnforceActiveTokenLimiter(t *testing.T) {
 				mockAccessTokenRepo.EXPECT().DeleteByIDs(ctx, []uuid.UUID{tobeDeletedAccessToken.ID}, true).Times(1).Return(nil)
 			},
 			Run: func() {
-				err := th.HandleEnforceActiveTokenLimitter(ctx, task)
+				err := th.HandleEnforceActiveTokenLimiter(ctx, task)
 				assert.NoError(t, err)
 			},
 		},

--- a/internal/worker/task_handler_test.go
+++ b/internal/worker/task_handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/luckyAkbar/atec-api/internal/model"
 	"github.com/luckyAkbar/atec-api/internal/model/mock"
 	"github.com/luckyAkbar/atec-api/internal/repository"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/sweet-go/stdlib/mail"
 	mailMock "github.com/sweet-go/stdlib/mail/mock"
@@ -29,6 +30,8 @@ func TestWorker_HandleSendEmail(t *testing.T) {
 
 	mockMailUtility := mailMock.NewMockUtility(ctrl)
 	mockMailRepo := mock.NewMockEmailRepository(ctrl)
+	mockUserRepo := mock.NewMockUserRepository(ctrl)
+	mockAccessTokenRepo := mock.NewMockAccessTokenRepository(ctrl)
 
 	normalLimiter := rate.NewLimiter(10, 20)
 	id := uuid.New()
@@ -77,7 +80,7 @@ func TestWorker_HandleSendEmail(t *testing.T) {
 		Subject:     email.Subject,
 	}
 
-	taskHandler := newTaskHandler(mockMailUtility, normalLimiter, mockMailRepo)
+	taskHandler := newTaskHandler(mockMailUtility, normalLimiter, mockMailRepo, mockUserRepo, mockAccessTokenRepo)
 
 	tests := []common.TestStructure{
 		{
@@ -105,7 +108,7 @@ func TestWorker_HandleSendEmail(t *testing.T) {
 			MockFn: func() {},
 			Run: func() {
 				rateLimited := rate.NewLimiter(0, 0)
-				rlTaskHandler := newTaskHandler(mockMailUtility, rateLimited, mockMailRepo)
+				rlTaskHandler := newTaskHandler(mockMailUtility, rateLimited, mockMailRepo, mockUserRepo, mockAccessTokenRepo)
 				err := rlTaskHandler.HandleSendEmail(ctx, task)
 				assert.Error(t, err)
 			},
@@ -176,6 +179,173 @@ func TestWorker_HandleSendEmail(t *testing.T) {
 			},
 			Run: func() {
 				err := taskHandler.HandleSendEmail(ctx, task)
+				assert.NoError(t, err)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt.MockFn()
+		tt.Run()
+	}
+}
+
+func TestTaskHandler_HandleEnforceActiveTokenLimiter(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	mockMailUtility := mailMock.NewMockUtility(ctrl)
+	mockMailRepo := mock.NewMockEmailRepository(ctrl)
+	mockUserRepo := mock.NewMockUserRepository(ctrl)
+	mockAccessTokenRepo := mock.NewMockAccessTokenRepository(ctrl)
+
+	normalLimiter := rate.NewLimiter(10, 20)
+	id := uuid.New()
+
+	payload, err := json.Marshal(id)
+	assert.NoError(t, err)
+
+	task := asynq.NewTask(string(model.TaskEnforceActiveTokenLimitter), payload)
+
+	th := newTaskHandler(mockMailUtility, normalLimiter, mockMailRepo, mockUserRepo, mockAccessTokenRepo)
+
+	activeTokenLimit := 5
+	viper.Set("server.auth.active_token_limit", activeTokenLimit)
+
+	belowLimitAccessToken := []model.AccessToken{}
+	for i := 0; i < activeTokenLimit; i++ {
+		belowLimitAccessToken = append(belowLimitAccessToken, model.AccessToken{
+			ID:        uuid.New(),
+			Token:     uuid.New().String(),
+			CreatedAt: time.Now().Add(time.Hour * -14),
+		})
+	}
+
+	tobeDeletedAccessToken := model.AccessToken{
+		ID:        uuid.New(),
+		Token:     uuid.New().String(),
+		CreatedAt: time.Now().Add(time.Hour * -99),
+	}
+
+	aboveLimitAccessToken := belowLimitAccessToken
+	aboveLimitAccessToken = append(aboveLimitAccessToken, tobeDeletedAccessToken)
+
+	user := &model.User{
+		ID: id,
+	}
+
+	tests := []common.TestStructure{
+		{
+			Name:   "invalid payload -> failed to unmarshal",
+			MockFn: func() {},
+			Run: func() {
+				_task := asynq.NewTask(string(model.TaskEnforceActiveTokenLimitter), []byte("][=-098765321234567890]["))
+				err := th.HandleEnforceActiveTokenLimitter(ctx, _task)
+
+				assert.Error(t, err)
+				assert.Equal(t, err.Error(), "invalid character ']' looking for beginning of value")
+			},
+		},
+		{
+			Name:   "got rate limited error",
+			MockFn: func() {},
+			Run: func() {
+				rateLimited := rate.NewLimiter(0, 0)
+				rlTaskHandler := newTaskHandler(mockMailUtility, rateLimited, mockMailRepo, mockUserRepo, mockAccessTokenRepo)
+				err := rlTaskHandler.HandleEnforceActiveTokenLimitter(ctx, task)
+				assert.Error(t, err)
+
+				assert.Equal(t, err, newWorkerRateLimitError())
+			},
+		},
+		{
+			Name: "failed to find user data",
+			MockFn: func() {
+				mockUserRepo.EXPECT().FindByID(ctx, id).Times(1).Return(nil, errors.New("err db"))
+			},
+			Run: func() {
+				err := th.HandleEnforceActiveTokenLimitter(ctx, task)
+				assert.Error(t, err)
+			},
+		},
+		{
+			Name: "got error not found from db -> continue without retrying",
+			MockFn: func() {
+				mockUserRepo.EXPECT().FindByID(ctx, id).Times(1).Return(nil, repository.ErrNotFound)
+			},
+			Run: func() {
+				err := th.HandleEnforceActiveTokenLimitter(ctx, task)
+				assert.NoError(t, err)
+			},
+		},
+		{
+			Name: "failed to find access tokens",
+			MockFn: func() {
+				mockUserRepo.EXPECT().FindByID(ctx, id).Times(1).Return(user, nil)
+				mockAccessTokenRepo.EXPECT().FindByUserID(ctx, user.ID, activeTokenLimit*2).Times(1).Return(nil, errors.New("err db"))
+			},
+			Run: func() {
+				err := th.HandleEnforceActiveTokenLimitter(ctx, task)
+				assert.Error(t, err)
+			},
+		},
+		{
+			Name: "no access token found, will continue without retrying",
+			MockFn: func() {
+				mockUserRepo.EXPECT().FindByID(ctx, id).Times(1).Return(user, nil)
+				mockAccessTokenRepo.EXPECT().FindByUserID(ctx, user.ID, activeTokenLimit*2).Times(1).Return(nil, repository.ErrNotFound)
+			},
+			Run: func() {
+				err := th.HandleEnforceActiveTokenLimitter(ctx, task)
+				assert.NoError(t, err)
+			},
+		},
+		{
+			Name: "active access token count still below upper limit",
+			MockFn: func() {
+				mockUserRepo.EXPECT().FindByID(ctx, id).Times(1).Return(user, nil)
+				mockAccessTokenRepo.EXPECT().FindByUserID(ctx, user.ID, activeTokenLimit*2).Times(1).Return(belowLimitAccessToken, nil)
+			},
+			Run: func() {
+				err := th.HandleEnforceActiveTokenLimitter(ctx, task)
+				assert.NoError(t, err)
+			},
+		},
+		{
+			Name: "access token are passing maximum limit, but fails when deleting cached creds",
+			MockFn: func() {
+				mockUserRepo.EXPECT().FindByID(ctx, id).Times(1).Return(user, nil)
+				mockAccessTokenRepo.EXPECT().FindByUserID(ctx, user.ID, activeTokenLimit*2).Times(1).Return(aboveLimitAccessToken, nil)
+				mockAccessTokenRepo.EXPECT().DeleteCredentialsFromCache(ctx, []string{tobeDeletedAccessToken.Token}).Times(1).Return(errors.New("err redis"))
+			},
+			Run: func() {
+				err := th.HandleEnforceActiveTokenLimitter(ctx, task)
+				assert.Error(t, err)
+			},
+		},
+		{
+			Name: "access token are passing maximum limit, but fails when deleting db record",
+			MockFn: func() {
+				mockUserRepo.EXPECT().FindByID(ctx, id).Times(1).Return(user, nil)
+				mockAccessTokenRepo.EXPECT().FindByUserID(ctx, user.ID, activeTokenLimit*2).Times(1).Return(aboveLimitAccessToken, nil)
+				mockAccessTokenRepo.EXPECT().DeleteCredentialsFromCache(ctx, []string{tobeDeletedAccessToken.Token}).Times(1).Return(nil)
+				mockAccessTokenRepo.EXPECT().DeleteByIDs(ctx, []uuid.UUID{tobeDeletedAccessToken.ID}, true).Times(1).Return(errors.New("err db"))
+			},
+			Run: func() {
+				err := th.HandleEnforceActiveTokenLimitter(ctx, task)
+				assert.Error(t, err)
+			},
+		},
+		{
+			Name: "access token are passing maximum limit, all process success",
+			MockFn: func() {
+				mockUserRepo.EXPECT().FindByID(ctx, id).Times(1).Return(user, nil)
+				mockAccessTokenRepo.EXPECT().FindByUserID(ctx, user.ID, activeTokenLimit*2).Times(1).Return(aboveLimitAccessToken, nil)
+				mockAccessTokenRepo.EXPECT().DeleteCredentialsFromCache(ctx, []string{tobeDeletedAccessToken.Token}).Times(1).Return(nil)
+				mockAccessTokenRepo.EXPECT().DeleteByIDs(ctx, []uuid.UUID{tobeDeletedAccessToken.ID}, true).Times(1).Return(nil)
+			},
+			Run: func() {
+				err := th.HandleEnforceActiveTokenLimitter(ctx, task)
 				assert.NoError(t, err)
 			},
 		},


### PR DESCRIPTION
adding functionality to limit the amount of active session from a given user

if set, when user's log in and get a new access token, the oldest active access token will be deleted
if left unset, no behavior change (can have unlimited active session)

relates to: https://lucky-akbar.atlassian.net/browse/ATEC-49